### PR TITLE
[CPP] Translate ICli interface from C#

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Interfaces/issues/99
-Your prepared branch: issue-99-0c25b77b
-Your prepared working directory: /tmp/gh-issue-solver-1757517995121
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Interfaces/issues/99
+Your prepared branch: issue-99-0c25b77b
+Your prepared working directory: /tmp/gh-issue-solver-1757517995121
+
+Proceed.

--- a/cpp/Platform.Interfaces.Tests/Platform.Interfaces.Tests.cpp
+++ b/cpp/Platform.Interfaces.Tests/Platform.Interfaces.Tests.cpp
@@ -140,4 +140,17 @@ namespace Platform::Interfaces::Tests {
       ASSERT_TRUE((CSetter<EmptyProperty, int, int&>));
     }
   }
+
+  TEST(CompileTests, Cli) {
+    struct EmptyCli : public ICli {
+      int Run(const std::vector<std::string>& args) override { return 0; }
+    };
+    static_assert(CCli<EmptyCli>);
+
+    {
+      CCli auto cli = EmptyCli{};
+
+      ASSERT_TRUE((CCli<EmptyCli>));
+    }
+  }
 }  // namespace Platform::Interfaces::Tests

--- a/cpp/Platform.Interfaces/CCli.h
+++ b/cpp/Platform.Interfaces/CCli.h
@@ -1,0 +1,12 @@
+﻿#pragma once
+
+#include <concepts>
+#include <string>
+#include <vector>
+
+namespace Platform::Interfaces {
+  template <typename TSelf>
+  concept CCli = requires(TSelf self, const std::vector<std::string>& args) {
+    { self.Run(args) } -> std::same_as<int>;
+  };
+}  // namespace Platform::Interfaces

--- a/cpp/Platform.Interfaces/ICli.h
+++ b/cpp/Platform.Interfaces/ICli.h
@@ -1,0 +1,28 @@
+﻿#pragma once
+
+#include <string>
+#include <vector>
+
+namespace Platform::Interfaces {
+  /// <summary>
+  /// <para>Defines command line interfaces for command that interacts with an operating system.</para>
+  /// <para>Определяет интерфейс командной строки, для команды взаимодействующей с операционной системой.</para>
+  /// </summary>
+  struct ICli {
+    /// <summary>
+    /// <para>Runs a command.</para>
+    /// <para>Запускает команду.</para>
+    /// </summary>
+    /// <param name="args">
+    /// <para>Arguments for a command.</para>
+    /// <para>Аргументы для команды.</para>
+    /// </param>
+    /// <returns>
+    /// <para>Returns command's exit code.</para>
+    /// <para>Возвращает код выхода команды.</para>
+    /// </returns>
+    virtual int Run(const std::vector<std::string>& args) = 0;
+
+    virtual ~ICli() = default;
+  };
+}  // namespace Platform::Interfaces

--- a/cpp/Platform.Interfaces/Platform.Interfaces.h
+++ b/cpp/Platform.Interfaces/Platform.Interfaces.h
@@ -14,6 +14,7 @@
 #include "CProvider.h"
 #include "CSetter.h"
 #include "CProperty.h"
+#include "CCli.h"
 
 #include "ICounter[TResult, TArgument].h"
 #include "ICounter[TResult].h"
@@ -25,6 +26,7 @@
 #include "IProvider[TProvided].h"
 #include "ISetter[TValue, TArgument].h"
 #include "ISetter[TValue].h"
+#include "ICli.h"
 
 #include "Polymorph.h"
 


### PR DESCRIPTION
## Summary

This PR translates the `ICli` interface from C# to C++ as requested in issue #99.

### Changes Made

- **ICli.h**: New interface with `Run` method that takes command line arguments and returns exit code
- **CCli.h**: Concept for compile-time verification of CLI implementations
- **Platform.Interfaces.h**: Updated to include the new interface and concept  
- **Tests**: Added comprehensive unit test following the project's testing patterns

### Implementation Details

- Translated `params string[] args` to `const std::vector<std::string>& args` for C++ compatibility
- Preserved bilingual documentation (English/Russian) matching C# version
- Followed existing project patterns and conventions
- Added virtual destructor following interface best practices
- Includes compile-time concept checking with static assertions

### Test Plan

- [x] Compiles successfully with g++ and C++20 standard
- [x] Static assertions verify concept implementation  
- [x] Unit test follows existing project test patterns
- [x] Interface matches C# functionality and documentation

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)