### PR TITLE
Use TObject& instead of TObject in CProperties concept

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Interfaces/issues/88
+Your prepared branch: issue-88-6ebf60d7
+Your prepared working directory: /tmp/gh-issue-solver-1757518255409
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Interfaces/issues/88
-Your prepared branch: issue-88-6ebf60d7
-Your prepared working directory: /tmp/gh-issue-solver-1757518255409
-
-Proceed.

--- a/cpp/Platform.Interfaces/CProperties.h
+++ b/cpp/Platform.Interfaces/CProperties.h
@@ -4,7 +4,7 @@
 
 namespace Platform::Interfaces {
   template <typename TSelf, typename TObject, typename TProperty, typename TValue>
-  concept CProperties = requires(TSelf self, TObject object, TProperty property, TValue value) {
+  concept CProperties = requires(TSelf self, TObject& object, TProperty property, TValue value) {
     { self.GetValue(object, property) } -> std::same_as<TValue>;
 
     { self.SetValue(object, property, value) } -> std::same_as<void>;


### PR DESCRIPTION
## Summary
- Fixed the CProperties concept to use `TObject&` instead of `TObject` in the requires expression
- This change allows the concept to work correctly when TObject is already a reference type (`int&`, `const int&`)

## Changes Made
- Modified `cpp/Platform.Interfaces/CProperties.h` line 7 to use `TObject& object` instead of `TObject object` in the concept requirements

## Test Plan
- [x] Created test programs to verify the concept works with value types (`int`)
- [x] Verified the concept works with reference types (`int&`)
- [x] Verified the concept works with const reference types (`const int&`)
- [x] Confirmed the change maintains backward compatibility
- [x] All concept static_assert tests pass

## Background
The issue was reported as needing to use `TObject&` instead of `TObject` in concepts. The problem was that when testing concepts with reference types like `CProperties<EmptyProperties, int&, int, int>`, the original definition using `TObject object` didn't handle reference type parameters optimally. By changing to `TObject& object`, the concept now works correctly with both value types and reference types.

Fixes #88

🤖 Generated with [Claude Code](https://claude.ai/code)