### PR TITLE
Fix DocFX warnings in documentation generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Interfaces/issues/36
-Your prepared branch: issue-36-682afee2
-Your prepared working directory: /tmp/gh-issue-solver-1757519095487
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Interfaces/issues/36
+Your prepared branch: issue-36-682afee2
+Your prepared working directory: /tmp/gh-issue-solver-1757519095487
+
+Proceed.

--- a/csharp/docfx.json
+++ b/csharp/docfx.json
@@ -1,0 +1,43 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [ "**/*.sln" ],
+          "exclude": [ "**/bin/**", "**/obj/**" ],
+          "src": ""
+        }
+      ],
+      "dest": "obj/api",
+      "filter": "filter.yml",
+      "properties": { "TargetFramework": "net8" }
+    }
+  ],
+  "build": {
+    "content": [
+      {
+        "files": [ "**/*.yml" ],
+        "src": "obj/api",
+        "dest": "api"
+      },
+      {
+        "files": [ "*.md", "toc.yml" ]
+      },
+      {
+        "files": [ "README.md" ],
+        "src": ".."
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "LinksPlatform's Platform.Interfaces Library",
+      "_enableSearch": true,
+      "_gitContribute": {
+        "branch": "master"
+      },
+      "_gitUrlPattern": "github"
+    },
+    "markdownEngineName": "markdig",
+    "dest": "_site",
+    "xrefService": [ "https://xref.docs.microsoft.com/query?uid={uid}" ]
+  }
+}

--- a/csharp/filter.yml
+++ b/csharp/filter.yml
@@ -1,0 +1,5 @@
+apiRules:
+- exclude:
+    uidRegex: (Tests|Benchmarks)(\.[A-Za-z]+)?$
+- exclude:
+    uidRegex: CSharpToCppTranslator$

--- a/csharp/toc.yml
+++ b/csharp/toc.yml
@@ -1,0 +1,5 @@
+- name: Home
+  href: README.md
+- name: API Documentation
+  href: obj/api/
+  homepage: api/Platform.Interfaces.html


### PR DESCRIPTION
## Summary
- Fixed TargetFramework mismatch from netstandard2.0 to net8 to align with project configuration
- Replaced $REPOSITORY_NAME template variable with actual repository name 'Interfaces'
- Configured proper file inclusion for README.md from parent directory
- Added DocFX configuration files (docfx.json, filter.yml, toc.yml) to repository

## Test plan
- [x] Run DocFX locally to verify warnings are resolved
- [x] Ensure documentation builds successfully with 0 errors and minimal warnings
- [x] Verify generated HTML files contain expected content
- [x] Test that the CI pipeline will use the updated configuration

The DocFX build now completes successfully with only expected file link warnings that occur during build-time but don't affect the final generated documentation.

Fixes #36

🤖 Generated with [Claude Code](https://claude.ai/code)