### PR TITLE
Fix C# workflow NU5017 packaging error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Interfaces/issues/142
-Your prepared branch: issue-142-b15af30d
-Your prepared working directory: /tmp/gh-issue-solver-1757697530449
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Interfaces/issues/142
+Your prepared branch: issue-142-b15af30d
+Your prepared working directory: /tmp/gh-issue-solver-1757697530449
+
+Proceed.

--- a/csharp/Platform.Interfaces/Platform.Interfaces.csproj
+++ b/csharp/Platform.Interfaces/Platform.Interfaces.csproj
@@ -22,9 +22,8 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <DebugType>embedded</DebugType>
     <LangVersion>latest</LangVersion>
-    <PackageReleaseNotes>Add embedded symbols support for GitHub Package Registry debugging.</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix NU5017 packaging error by removing conflicting DebugType setting.</PackageReleaseNotes>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary
Fixed the C# workflow failure caused by NU5017 packaging error: "Cannot create a package that has no dependencies nor content".

## Root Cause
The issue was caused by a conflicting MSBuild configuration where:
- `<DebugType>embedded</DebugType>` embeds debug symbols directly into the main assembly
- `<IncludeSymbols>true</IncludeSymbols>` and `<SymbolPackageFormat>snupkg</SymbolPackageFormat>` attempt to create a separate symbol package
- This resulted in an empty symbol package with no content, triggering the NU5017 error

## Solution
- Removed the `<DebugType>embedded</DebugType>` setting to allow proper symbol package generation
- Kept the symbol package settings (`IncludeSymbols` and `SymbolPackageFormat`) to maintain debugging support
- Updated package release notes to document the fix

## Verification
✅ Local testing confirms:
- `dotnet build -c Release` - succeeds
- `dotnet test -c Release -f net8` - all tests pass
- `dotnet pack -c Release --include-symbols` - both .nupkg and .snupkg created successfully

The fix aligns with other successful repositories in the linksplatform organization that use the same symbol packaging configuration without the conflicting DebugType setting.

## Test plan
- [x] Verify local build and test commands work
- [x] Confirm NuGet package creation succeeds
- [ ] Wait for CI workflow to pass after merge

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #142