### PR TITLE
Add CodeQL Badge

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,69 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: '43 3 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp', 'csharp' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended,security-and-quality
+
+    - name: Setup .NET (for C# analysis)
+      if: matrix.language == 'csharp'
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Build C#
+      if: matrix.language == 'csharp'
+      run: |
+        cd csharp
+        dotnet restore
+        dotnet build -c Release
+
+    - name: Install dependencies (for C++ analysis)
+      if: matrix.language == 'cpp'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake build-essential
+
+    - name: Build C++
+      if: matrix.language == 'cpp'
+      run: |
+        cd cpp
+        mkdir -p build
+        cd build
+        cmake ..
+        make
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Interfaces/issues/139
+Your prepared branch: issue-139-6bab94f7
+Your prepared working directory: /tmp/gh-issue-solver-1757698169243
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Interfaces/issues/139
-Your prepared branch: issue-139-6bab94f7
-Your prepared working directory: /tmp/gh-issue-solver-1757698169243
-
-Proceed.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/93857535a2214ba9b512e1a88787d461)](https://app.codacy.com/gh/linksplatform/Interfaces?utm_source=github.com&utm_medium=referral&utm_content=linksplatform/Interfaces&utm_campaign=Badge_Grade_Settings)
 [![CodeFactor](https://www.codefactor.io/repository/github/linksplatform/interfaces/badge)](https://www.codefactor.io/repository/github/linksplatform/interfaces)
+[![CodeQL](https://github.com/linksplatform/Interfaces/actions/workflows/codeql.yml/badge.svg)](https://github.com/linksplatform/Interfaces/actions/workflows/codeql.yml)
 
 | [![Actions Status](https://github.com/linksplatform/Interfaces/workflows/deploy-cpp/badge.svg)](https://github.com/linksplatform/Interfaces/actions?workflow=deploy-cpp) | [![NuGet Version and Downloads count](https://img.shields.io/nuget/v/Platform.Interfaces.TemplateLibrary?label=nuget&style=flat)](https://www.nuget.org/packages/Platform.Interfaces.TemplateLibrary) [![ConanCenter package](https://repology.org/badge/version-for-repo/conancenter/platform.interfaces.svg)](https://conan.io/center/platform.interfaces) | __C++__  |
 |-|-|-|


### PR DESCRIPTION
## Summary
This PR adds CodeQL security analysis workflow and badge as requested in issue #139.

## Changes Made
- Added `.github/workflows/codeql.yml` workflow file that:
  - Analyzes both C# and C++ code for security vulnerabilities
  - Runs on push to main, pull requests, and weekly schedule
  - Uses GitHub's CodeQL security-extended and security-and-quality queries
- Added CodeQL badge to README.md showing the security analysis status

## Testing
- The workflow is configured to run automatically when merged
- Badge will display the current status once the workflow runs

Fixes #139

🤖 Generated with [Claude Code](https://claude.ai/code)